### PR TITLE
Last minute v16.1 inclusions (somewhat bugfix...)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,13 +67,13 @@ It is possible to check for and install updates from the Drupal Admin
 UI:: **Admin > Reports > Available Updates**
 
 Updates for Drupal9 Core often need to be done via commandline. For full
-details, please consult the `Drupal8 Upgrade docs`_, we recommend using
-`Composer to update from the commandline`_::
+details, please consult the `Drupal Upgrade docs`_, we recommend using
+`Composer to update from the commandline`_ (via turnkey-composer_)::
 
     cd /var/www/drupal9
     # update composer - not strictly necessary
     composer self-update
-    turnkey-composer update drupal/core webflo/drupal-core-require-dev --with-dependencies
+    turnkey-composer update drupal/core --with-dependencies
     turnkey-drush updatedb -y
     turnkey-drush cr
 
@@ -86,17 +86,6 @@ Modules can be updated like this, e.g. ctools::
 We also recommend that you  subscribe to the drupal.org security
 newsletter (create a user account on drupal.org and within your drupal.org
 profile:: **Edit > My newsletter** tab).
-
-Notes on documentation
-----------------------
-
-The links here relevant to documentation all link to drupal 8
-documentation, this is not an accident but rather due to the fact that
-as of writing there are no drupal 9 documentation specifically. This
-AFAIK is partially (or wholly perhaps) due to the fact that the
-changes between drupal 8 and 9 are rather small, and mostly not apparent
-on the surface. As such the documentation for drupal 8 should largely
-suffice.
 
 
 Credentials *(passwords set at first boot)*
@@ -123,5 +112,5 @@ Credentials *(passwords set at first boot)*
 .. _PathAuto: https://drupal.org/project/pathauto
 .. _Token: https://drupal.org/project/token
 .. _Adminer: https://www.adminer.org
-.. _Drupal8 Upgrade docs: https://www.drupal.org/docs/8/update
-.. _Composer to update from the commandline: https://www.drupal.org/docs/8/update/update-core-via-composer
+.. _Drupal Upgrade docs: https://www.drupal.org/docs/updating-drupal
+.. _Composer to update from the commandline: https://www.drupal.org/docs/updating-drupal/updating-drupal-core-via-composer

--- a/changelog
+++ b/changelog
@@ -4,6 +4,8 @@ turnkey-drupal9-16.1 (1) turnkey; urgency=low
 
   * Update Drush to latest - 10.3.6.
 
+  * Include Drupal Console - 1.9.7 - closes #1564.
+
   * Drupal 9 files & directories all owned by 'www-data' user to make
     management easier. Note that whilst this does make management easier,
     (especially in conjunction with 'turnkey-composer') it does have
@@ -12,13 +14,15 @@ turnkey-drupal9-16.1 (1) turnkey; urgency=low
   * Include 'turnkey-composer' wrapper script - runs composer as www-data
     user. Makes it easy to not run composer as root - part of #1539.
 
+  * Also include 'turnkey-drush' and 'turnkey-drupal' wrapper scripts.
+
   * Explicitly install composer (rather than automatically include in all LAMP
     based appliances) - part of #1563.
 
   * Note: Please refer to turnkey-core's 16.1 changelog for changes common to
     all appliances. Here we only describe changes specific to this appliance.
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 10 Feb 2021 16:00:16 +1100
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Tue, 16 Feb 2021 11:28:09 +1100
 
 turnkey-drupal9-16.0 (1) turnkey; urgency=low
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -39,6 +39,16 @@ wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/release
 chmod +x /usr/local/bin/drush
 drush self-update
 
+# install drupal console
+cd $WEBROOT
+turnkey-composer require drupal/console --prefer-dist --optimize-autoloader --no-interaction --with-all-dependencies
+
+# install drupal console launcher
+cd / # drupal self-update fails from WEBROOT?!
+wget -O /usr/local/bin/drupal -L https://drupalconsole.com/installer
+chmod +x /usr/local/bin/drupal
+drupal self-update
+
 CONF=$WEBROOT/web/sites/default/settings.php
 cp $WEBROOT/web/sites/default/default.settings.php $CONF
 

--- a/overlay/usr/local/bin/turnkey-drupal
+++ b/overlay/usr/local/bin/turnkey-drupal
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+[[ -z "$DEBUG" ]] || set -x
+
+export DRUPAL_USER="${DRUPAL_USER:-www-data}"
+
+COMMAND="drupal $@"
+
+runuser $DRUPAL_USER -s /bin/bash -c "$COMMAND"

--- a/overlay/usr/local/bin/turnkey-drush
+++ b/overlay/usr/local/bin/turnkey-drush
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+[[ -z "$DEBUG" ]] || set -x
+
+export DRUSH_USER="${DRUSH_USER:-www-data}"
+
+COMMAND="drush $@"
+
+runuser $DRUSH_USER -s /bin/bash -c "$COMMAND"


### PR DESCRIPTION
Actually include the `turnkey-drush` & `turnkey-drupal` wrapper scripts that the readme notes...

Also install `drupal-conconsole` (it's now compatible with D9) - closes https://github.com/turnkeylinux/tracker/issues/1564.